### PR TITLE
now with user-supplied ssh key

### DIFF
--- a/terraform-aws/_interface.tf
+++ b/terraform-aws/_interface.tf
@@ -44,6 +44,10 @@ variable "os_version" {
   description = "Operating System version to use ie 7.3 (for RHEL) or 16.04 (for Ubuntu)"
 }
 
+variable "ssh_key_name" {
+  description = "Name of SSH key populated to nodes. This key must be pre-existing."
+}
+
 ## Outputs
 output "vpc_id" {
   value = "${module.network-aws.vpc_id}"
@@ -85,10 +89,3 @@ output "hashistack_server_sg_id" {
   value = "${module.hashistack-aws.hashistack_server_sg_id}"
 }
 
-output "ssh_key_name" {
-  value = "${module.ssh-keypair-aws.ssh_key_name}"
-}
-
-output "private_key_data" {
-  value = "${module.ssh-keypair-aws.private_key_data}"
-}

--- a/terraform-aws/main.tf
+++ b/terraform-aws/main.tf
@@ -9,11 +9,11 @@ provider "aws" {
 }
 
 module "network-aws" {
-  source           = "git::ssh://git@github.com/hashicorp-modules/network-aws?ref=fix_ssh_username_lookup_case"
+  source           = "git::ssh://git@github.com/hashicorp-modules/network-aws?ref=0.1.1"
   environment_name = "${random_id.environment_name.hex}"
   os               = "${var.os}"
   os_version       = "${var.os_version}"
-  ssh_key_name     = "${module.ssh-keypair-aws.ssh_key_name}"
+  ssh_key_name     = "${var.ssh_key_name}"
 }
 
 module "hashistack-aws" {
@@ -23,13 +23,9 @@ module "hashistack-aws" {
   cluster_size     = "${var.cluster_size}"
   os               = "${var.os}"
   os_version       = "${var.os_version}"
-  ssh_key_name     = "${module.ssh-keypair-aws.ssh_key_name}"
+  ssh_key_name     = "${var.ssh_key_name}"
   subnet_ids       = "${module.network-aws.subnet_private_ids}"
   vpc_id           = "${module.network-aws.vpc_id}"
   instance_type    = "${var.instance_type}"
 }
 
-module "ssh-keypair-aws" {
-  source       = "git::ssh://git@github.com/hashicorp-modules/ssh-keypair-aws"
-  ssh_key_name = "${random_id.environment_name.hex}"
-}

--- a/terraform-aws/main.tf
+++ b/terraform-aws/main.tf
@@ -9,7 +9,7 @@ provider "aws" {
 }
 
 module "network-aws" {
-  source           = "git::ssh://git@github.com/hashicorp-modules/network-aws?ref=0.1.1"
+  source           = "github.com/hashicorp-modules/network-aws?ref=0.1.1"
   environment_name = "${random_id.environment_name.hex}"
   os               = "${var.os}"
   os_version       = "${var.os_version}"


### PR DESCRIPTION
Old approach was to generate a temporary SSH key to be used for auth to nodes. The priv key was dumped into the working directory of the 'terraform plan'. When this module was wired into a TFE pipeline there was no way to get the key data. For the work I was doing this meant inability to then leverage TFE and specifically TFE Auto Apply work flow.

New code takes the name of a pre-existing SSH key and populates the nodes with pub key by that name.
  